### PR TITLE
db_drift_checker: only call get_shard_mapping() when needed

### DIFF
--- a/db_drift_checker.py
+++ b/db_drift_checker.py
@@ -202,7 +202,6 @@ def handle_category(category):
                 'time_start': time.time()
             }
         }))
-    shard_mapping = get_shard_mapping(args.dc)
 
     if category in schema_config:
         sql_data = []
@@ -212,6 +211,7 @@ def handle_category(category):
     else:
         raise Exception
     if args.prod:
+        shard_mapping = get_shard_mapping(args.dc)
         if schema_config[category].get('dblist'):
             handle_dblist(schema_config[category]['dblist'], sql_data, shard_mapping, args.all)
         else:


### PR DESCRIPTION
When using this tool to analyze drifts on a local wiki (i.e. localhost), get_shard_mapping() is called even though the results are only used when analyzing a (WMF) production wiki.

Improve support for other users of the tool by only calling get_shard_mapping() when analyzing a WMF production wiki.