### PR TITLE
db_drift_checker: add check for auto_increment mismatch

### DIFF
--- a/db_drift_checker.py
+++ b/db_drift_checker.py
@@ -105,6 +105,11 @@ def compare_table_with_prod(db, expected_table, actual_table):
             actual_column['IS_NULLABLE'].lower(),
             checker)
 
+        checker.run_check(
+            'field-auto-increment-mismatch',
+            ( 'auto_increment' in actual_column['EXTRA'] ) != expected.auto_increment
+        )
+
     for column in expected_table['columns']:
         checker = checker_factory.get_checker(actual_column['COLUMN_NAME'])
         checker.run_check(


### PR DESCRIPTION
No idea how, but we had a wiki where some of the fields that should have been auto_increment were not, which broke some things after updating.