### PR TITLE
Add new option `--skip-host` to avoid sending host parameter

### DIFF
--- a/data_access/sql.py
+++ b/data_access/sql.py
@@ -3,7 +3,7 @@ import sys
 from subprocess import PIPE, TimeoutExpired, run
 
 
-def get_table_structure_sql(host, sql_command, db, dc):
+def get_table_structure_sql(host, sql_command, db, dc, skip_host):
     port = None
     if host != 'localhost':
         if re.search(r' \-\-(?: |$)', sql_command):
@@ -15,10 +15,12 @@ def get_table_structure_sql(host, sql_command, db, dc):
         host += '.{}.wmnet'.format(dc)
     if port:
         sql_command += ' -P ' + port
-    command = 'timeout 6 {} -h {} -e ' + \
+    if not skip_host:
+        sql_command += '-h ' + host
+    command = 'timeout 6 {} -e ' + \
         '"select * FROM information_schema.columns WHERE table_schema = \'{}\'\\G; ' + \
         'SELECT * FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = \'{}\'\\G;"'
-    command = command.format(sql_command, host, db, db)
+    command = command.format(sql_command, db, db)
     try:
         res = run(
             command,

--- a/db_drift_checker.py
+++ b/db_drift_checker.py
@@ -36,6 +36,10 @@ parser.add_argument(
 parser.add_argument(
     '--dc', default='eqiad',
     help='All wikis in sections')
+parser.add_argument(
+    '--skip-host', action='store_true',
+    help='Skip the addition of the host parameter to the sql command invocation'
+)
 
 args = parser.parse_args()
 
@@ -173,7 +177,7 @@ def handle_wiki(shard, sql_data, hosts, wiki, sql_command):
         if args.wiki:
             wiki = args.wiki
         print(wiki, host)
-        res = get_table_structure_sql(host, sql_command, wiki, args.dc)
+        res = get_table_structure_sql(host, sql_command, wiki, args.dc, args.skip_host)
         data_ = defaultdict(list)
         for row in res.split('\n******'):
             def_ = re.findall(


### PR DESCRIPTION
In the context of MediaWiki, the easiest method to connect to the MySQL database can frequently be using the `maintenance/mysql.php` maintenance script, e.g. with `php maintenance/run mysql`. However, the inclusion of the `-h` (short for `--host`) parameter to the sql invocation prevents using the MediaWiki maintenance script in some cases:

* For supporting localhost invocation, i.e. when `--prod` is not provided to the drift checker invocation, the host is always considered to be "localhost" by `handle_category()`.
* If the command given to the drift checker is `php maintenance/run mysql`, the drift checker will then run `php maintenance/run mysql -h localhost {query}`, at which point the `-h` will be interpreted as the short form for `--help` by MediaWiki's maintenance argument parsing, and the script will show help information rather than running the specified query.
* If the command given to the drift checker is `php maintenance/run mysql --`, the drift checker will then run
`php maintenance/run mysql -- -h localhost {query}`, at which point MySQL will attempt to connect through a local socket. However, not all wikis running locally have MySQL running on the same host, e.g. when using separate docker containers for a wiki and its database.

Add a new command line option, `--skip-host`, that will skip the addition of the `-h {host}` parameter in the invocation of the sql command.