### PR TITLE
db_drift_checker: Add `--gerrit-schema-file` option and 'custom' type

### DIFF
--- a/abstract_paths.json
+++ b/abstract_paths.json
@@ -1,7 +1,7 @@
 {
     "core": {
         "path": [
-            "mediawiki/core/+/master/maintenance/tables.json"
+            "mediawiki/core/+/master/sql/tables.json"
         ]
     },
     "abusefilter": {


### PR DESCRIPTION
Not all wikis are running the latest development version of MediaWiki with its associated schema. Allow users to manually specify the location of the abstract schema file against which to check drifts, e.g. with `--gerrit-schema-file "mediawiki/core/+/REL1_43/maintenance/tables.json"` to check against MediaWiki's 1.43 schema. The new argument is only supported when the type of check to perform is specified as 'custom', to avoid confusion as to what happens when a type that the tool supports is requested but with a different schema file.

Additionally, in the bundled abstract_paths.json, update the path to the tables.json file for MediaWiki core, which was moved to a new `sql/` directory in T382030.